### PR TITLE
48 task reviews on single movie page should show the newest first

### DIFF
--- a/src/components/reviews/ReviewsList.jsx
+++ b/src/components/reviews/ReviewsList.jsx
@@ -7,10 +7,12 @@ export default function ReviewsList({ reviews }) {
 	const [currentPage, setCurrentPage] = useState(1);
 
 	const totalPages = Math.ceil(reviews.length / REVIEWS_PER_PAGE);
-	const paginatedReviews = reviews.slice(
-		(currentPage - 1) * REVIEWS_PER_PAGE,
-		currentPage * REVIEWS_PER_PAGE
-	);
+	const paginatedReviews = [...reviews]
+		.reverse()
+		.slice(
+			(currentPage - 1) * REVIEWS_PER_PAGE,
+			currentPage * REVIEWS_PER_PAGE
+		);
 
 	return (
 		<div className="space-y-2">


### PR DESCRIPTION
### Description
this was a small fix for the reviews so that the newest review will now be on top, 

Fixes # (issue)

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
this has been tested by creating new reviews and making sure that the newest one is on top

- [x] make new reviews and make sure that its the first one
- [ ] Test B

### Checklist:
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation if necessary.
- [ ] New and existing tests pass with my changes.

### Additional Notes
Add any other relevant information here.
