### PR TITLE
58 task implement future movie releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MONGO_URI=mongodb://localhost:27017
 
 ### GET the 5 Nearest Upcoming Screenings
 
-- **URL**: `/api/screenings/next`
+- **URL**: `/api/screenings/currently-showing`
 - **Method**: `GET`
 - **Description**: Returns the 5 upcoming screenings starting from the current time, sorted chronologically. Each screening is unique per movie and only includes films currently shown in cinemas.
 - **Response**: JSON array of screening objects with embedded movie data.
@@ -40,6 +40,30 @@ MONGO_URI=mongodb://localhost:27017
     "auditoriumId": "68164b2ef469735514b5f89a",
     "startTime": "2025-05-08T00:00:00.000Z"
   }
+  ]
+  ```
+
+  ### GET the 5 Nearest Upcoming Screenings
+
+- **URL**: `/api/screenings/upcoming-movies`
+- **Method**: `GET`
+- **Description**: Returns the 5 upcoming movies starting from the current date, sorted by release date. Each movie is unique and only includes movies that has not been released yet.
+- **Response**: JSON array of screening objects with embedded movie data.
+- **Example Response**:
+
+  ```
+  [
+  {
+  description: "The wildly funny and touching story of a lonely Hawaiian girl and the fugitive alien who helps to mend her broken family."
+  image: "https://image.tmdb.org/t/p/original//3bN675X0K2E5QiAZVChzB5wq90B.jpg"
+  inCinemas: true
+  rating: "0"
+  title: "Lilo & Stitch"
+  trailerKey: "VWqJifMMgZE"
+  year: "2025-05-21"
+  __v: 0
+  _id: "681f096a03071d53657a5f47"
+  },
   ]
   ```
 

--- a/src/app/api/screenings/currently-showing/route.js
+++ b/src/app/api/screenings/currently-showing/route.js
@@ -53,16 +53,6 @@ export const GET = async () => {
                 $unwind: "$movie"
             },
             {
-                $match: {
-                    $expr: {
-                        $lte: [
-                            { $dateFromString: { dateString: "$movie.year" } },
-                            new Date()
-                        ]
-                    }
-                }
-            },
-            {
                 $replaceRoot: {
                     newRoot: {
                         $mergeObjects: ["$movie", "$$ROOT"]

--- a/src/app/api/screenings/currently-showing/route.js
+++ b/src/app/api/screenings/currently-showing/route.js
@@ -53,6 +53,16 @@ export const GET = async () => {
                 $unwind: "$movie"
             },
             {
+                $match: {
+                    $expr: {
+                        $lte: [
+                            { $dateFromString: { dateString: "$movie.year" } },
+                            new Date()
+                        ]
+                    }
+                }
+            },
+            {
                 $replaceRoot: {
                     newRoot: {
                         $mergeObjects: ["$movie", "$$ROOT"]

--- a/src/app/api/screenings/upcoming-movies/route.js
+++ b/src/app/api/screenings/upcoming-movies/route.js
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import connectDB from "src/lib/mongodb";
+import Movie from "src/models/model.movies";
+
+export const GET = async () => {
+    try {
+        await connectDB();
+
+        const upcomingMovies = await Movie.aggregate([
+            {
+                $match: {
+                    $expr: {
+                        $gte: [
+                            { $dateFromString: { dateString: "$year" } },
+                            new Date()
+                        ]
+                    }
+                }
+            },
+            {
+                $sort: {
+                    year: 1
+                }
+            },
+            {
+                $limit: 5
+            }
+        ]);
+
+        return NextResponse.json(upcomingMovies, { status: 200 });
+    } catch (error) {
+        console.error("Error fetching upcoming screenings", error);
+        return NextResponse.json({ error: "Failed to fetch screenings" }, { status: 500 });
+    }
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -17,8 +17,6 @@ const Main = () => {
       try {
         const res = await fetch('/api/screenings/currently-showing');
         const data = await res.json();
-        console.log(data);
-
         setMovies(data);
       } catch (error) {
         console.error('Error fetching movies:', error);
@@ -64,8 +62,8 @@ const Main = () => {
         <div className="max-w-screen-2xl mx-auto px-0 sm:px-0" >
           <div className="relative mx-auto w-full border-4 border-yellow-400 shadow-[inset_0_0_10px_#facc15,0_0_20px_#facc15]">
             <TrailerCarousel trailerMovies={trailerMovies} />
-            <div className="w-full max-w-screen-xl mx-auto px-4 my-6">
-              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">FILMER PÅ KINO</h1>
+            <section className="w-full max-w-screen-xl mx-auto px-4 my-6">
+              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">JUST NU</h1>
 
               {error && (
                 <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -63,7 +63,7 @@ const Main = () => {
           <div className="relative mx-auto w-full border-4 border-yellow-400 shadow-[inset_0_0_10px_#facc15,0_0_20px_#facc15]">
             <TrailerCarousel trailerMovies={trailerMovies} />
             <section className="w-full max-w-screen-xl mx-auto px-4 my-6">
-              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">JUST NU</h1>
+              <h2 className="text-3xl text-[#CDCDCD] font-bold text-center">VISAS JUST NU</h2>
 
               {error && (
                 <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">
@@ -76,7 +76,7 @@ const Main = () => {
               )}
 
               {/* Grid for the cards */}
-              <div className="flex flex-row overflow-auto px-2 py-8 w-full lg:justify-center">
+              <div className="flex flex-row overflow-auto px-2 py-8 w-full xl:justify-center">
                 {(loading ? Array.from({ length: 5 }) : movies).map((movie, i) => (
                   <div key={movie?._id || i} className="flex justify-center">
                     {loading ? (
@@ -101,7 +101,7 @@ const Main = () => {
                 </div>
               )}
 
-              <div className="flex flex-row overflow-auto px-2 py-8 w-full lg:justify-center">
+              <div className="flex flex-row overflow-auto px-2 py-8 w-full xl:justify-center">
                 {(loading ? Array.from({ length: 5 }) : upcomingMovies).map((movie, i) => (
                   <div key={movie?._id || i} className="flex justify-start">
                     {loading ? (

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -33,8 +33,6 @@ const Main = () => {
       try {
         const res = await fetch('/api/screenings/upcoming-movies');
         const data = await res.json();
-        console.log(data);
-
         setUpcomigMovies(data);
       } catch (error) {
         console.error('Error fetching movies:', error);

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -92,9 +92,9 @@ const Main = () => {
               )}
 
               {/* Grid for the cards */}
-              <div className="flex flex-row overflow-auto px-2 py-8 w-full">
+              <div className="flex flex-row overflow-auto px-2 py-8 w-full lg:justify-center">
                 {(loading ? Array.from({ length: 5 }) : movies).map((movie, i) => (
-                  <div key={movie?._id || i} className="flex justify-start">
+                  <div key={movie?._id || i} className="flex justify-center">
                     {loading ? (
                       <MovieCardSkeleton />
                     ) : (
@@ -117,7 +117,7 @@ const Main = () => {
                 </div>
               )}
 
-              <div className="flex flex-row overflow-auto px-2 py-8 w-full">
+              <div className="flex flex-row overflow-auto px-2 py-8 w-full lg:justify-center">
                 {(loading ? Array.from({ length: 5 }) : upcomingMovies).map((movie, i) => (
                   <div key={movie?._id || i} className="flex justify-start">
                     {loading ? (

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -9,13 +9,34 @@ const Main = () => {
   const [movies, setMovies] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [upcomingMovies, setUpcomigMovies] = useState([]);
+
+  useEffect(() => {
+    const fetchCurrentMovies = async () => {
+      try {
+        const res = await fetch('/api/screenings/currently-showing');
+        const data = await res.json();
+        console.log(data);
+
+        setMovies(data);
+      } catch (error) {
+        console.error('Error fetching movies:', error);
+        setError('Vi har för tillfället problem med att hämta filmer.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCurrentMovies();
+  }, []);
 
   useEffect(() => {
     const fetchUpcomingMovies = async () => {
       try {
-        const res = await fetch('/api/screenings/next');
+        const res = await fetch('/api/screenings/upcoming-movies');
         const data = await res.json();
-        setMovies(data);
+        console.log(data);
+
+        setUpcomigMovies(data);
       } catch (error) {
         console.error('Error fetching movies:', error);
         setError('Vi har för tillfället problem med att hämta filmer.');
@@ -58,7 +79,7 @@ const Main = () => {
             )}
 
             <div className="w-full max-w-screen-xl mx-auto px-4 my-6">
-              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">FILMER PÅ KINO</h1>
+              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">JUST NU</h1>
 
               {error && (
                 <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">
@@ -73,6 +94,32 @@ const Main = () => {
               {/* Grid for the cards */}
               <div className="flex flex-row overflow-auto px-2 py-8 w-full">
                 {(loading ? Array.from({ length: 5 }) : movies).map((movie, i) => (
+                  <div key={movie?._id || i} className="flex justify-start">
+                    {loading ? (
+                      <MovieCardSkeleton />
+                    ) : (
+                      <MovieCard movie={movie} />
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="w-full max-w-screen-xl mx-auto px-4 my-6">
+              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">KOMMANDE FILMER</h1>
+
+              {error && (
+                <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">
+                  <div className="text-center text-black flex flex-col items-center">
+                    <Info />
+                    <span className="font-bold text-xl">Fel</span>
+                    <strong className="text-sm text-black font-bold text-xl">{error}</strong>
+                  </div>
+                </div>
+              )}
+
+              {/* Grid for the cards */}
+              <div className="flex flex-row overflow-auto px-2 py-8 w-full">
+                {(loading ? Array.from({ length: 5 }) : upcomingMovies).map((movie, i) => (
                   <div key={movie?._id || i} className="flex justify-start">
                     {loading ? (
                       <MovieCardSkeleton />

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -78,8 +78,8 @@ const Main = () => {
               </div>
             )}
 
-            <div className="w-full max-w-screen-xl mx-auto px-4 my-6">
-              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">JUST NU</h1>
+            <section className="w-full max-w-screen-xl mx-auto px-4 my-6">
+              <h2 className="text-3xl text-[#CDCDCD] font-bold text-center">JUST NU</h2>
 
               {error && (
                 <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">
@@ -103,9 +103,9 @@ const Main = () => {
                   </div>
                 ))}
               </div>
-            </div>
-            <div className="w-full max-w-screen-xl mx-auto px-4 my-6">
-              <h1 className="text-3xl text-[#CDCDCD] font-bold text-center">KOMMANDE FILMER</h1>
+            </section>
+            <section className="w-full max-w-screen-xl mx-auto px-4 my-6">
+              <h2 className="text-3xl text-[#CDCDCD] font-bold text-center">KOMMANDE FILMER</h2>
 
               {error && (
                 <div className="alert alert-warning shadow-lg justify-center mx-auto my-10 max-w-full">
@@ -117,7 +117,6 @@ const Main = () => {
                 </div>
               )}
 
-              {/* Grid for the cards */}
               <div className="flex flex-row overflow-auto px-2 py-8 w-full">
                 {(loading ? Array.from({ length: 5 }) : upcomingMovies).map((movie, i) => (
                   <div key={movie?._id || i} className="flex justify-start">
@@ -129,7 +128,7 @@ const Main = () => {
                   </div>
                 ))}
               </div>
-            </div>
+            </section>
             <div>
               <div className="flex flex-col md:flex-row justify-center items-center gap-4 md:gap-20">
                 <a href="/movies" className="bg-transparent hover:bg-[#CDCDCD] text-[#CDCDCD] font-semibold hover:text-[#2B0404] py-2 px-4 rounded transition-all duration-300 ease-in-out border border-gray-200 hover:border-transparent rounded hover:cursor-pointer hover:shadow-[0_4px_15px_rgba(0,0,0,0.2)] hover:scale-105 backdrop-brightness-110">

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -11,6 +11,7 @@ const MovieCard = ({ movie }) => {
 
 	const ratingNum = parseFloat(movie.rating);
 	const roundedRating = isNaN(ratingNum) ? 'N/A' : Math.round(ratingNum * 10) / 10;
+	const hasRating = roundedRating !== null && roundedRating > 0;
 
 	let formattedDate = null;
 	let formattedTime = null;
@@ -31,7 +32,7 @@ const MovieCard = ({ movie }) => {
 	}
 
 	return (
-		<div className="group relative">
+		<article className="group relative">
 			<div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transition-all duration-300 opacity-0 group-hover:opacity-100 w-48 h-79">
 				<img
 					src={movie.image}
@@ -48,6 +49,7 @@ const MovieCard = ({ movie }) => {
 				href={`/movies/${movie.movieId ?? movie._id}`}
 				className="relative block w-50 h-83 rounded overflow-hidden shadow-lg mx-4 my-2"
 				id={movie.movieId ?? movie._id}
+				aria-labelledby={`movie-title-${movie.movieId ?? movie._id}`}
 			>
 				<img
 					src={movie.image}
@@ -61,7 +63,9 @@ const MovieCard = ({ movie }) => {
 
 				<div className="absolute bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.86)] text-white p-2 opacity-100 sm:opacity-100 xl:opacity-0 group-hover:opacity-100 xl:group-hover:opacity-100 transition-opacity duration-300">
 					<h2 className="text-lg font-semibold truncate">{movie.title}</h2>
-					<p className="text-sm">{roundedRating}⭐</p>
+					{hasRating && (
+						<p className="text-sm"><span aria-label={`${roundedRating} out of 10 rating`}>{roundedRating}⭐</span></p>
+					)}
 					{formattedDate && formattedTime ? (
 						<>
 							<p>{formattedDate}</p>
@@ -76,7 +80,7 @@ const MovieCard = ({ movie }) => {
 
 				</div>
 			</Link>
-		</div>
+		</article>
 	);
 }
 

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -71,11 +71,13 @@ const MovieCard = ({ movie }) => {
 							<p>{formattedDate}</p>
 							<p>{formattedTime}</p>
 						</>
-					) : (
+					) : new Date(movie.year) > new Date() ? (
 						<>
 							<p>Premiär</p>
 							<p>{movie.year}</p>
 						</>
+					) : (
+						''
 					)}
 
 				</div>

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -62,8 +62,18 @@ const MovieCard = ({ movie }) => {
 				<div className="absolute bottom-0 left-0 right-0 bg-[rgba(0,0,0,0.86)] text-white p-2 opacity-100 sm:opacity-100 xl:opacity-0 group-hover:opacity-100 xl:group-hover:opacity-100 transition-opacity duration-300">
 					<h2 className="text-lg font-semibold truncate">{movie.title}</h2>
 					<p className="text-sm">{roundedRating}⭐</p>
-					<p>{formattedDate}</p>
-					<p>{formattedTime}</p>
+					{formattedDate && formattedTime ? (
+						<>
+							<p>{formattedDate}</p>
+							<p>{formattedTime}</p>
+						</>
+					) : (
+						<>
+							<p>Premiär</p>
+							<p>{movie.year}</p>
+						</>
+					)}
+
 				</div>
 			</Link>
 		</div>


### PR DESCRIPTION
### Description
#### Divide frontpage movies
I've divided the frontpage movies into "Just nu" and "Kommande visningar".
**Just nu** only displays:
- Movies with screenings and only the closest screening to the current date for each movie.

**Kommande visningar** only displays
- Movies which year attribute is greater than current date.

I've also made minor changes to breakpoints for the frontpage card divs as well as updated them to be a bit more semantic.

#### MovieCard
- I've updated the MovieCard to be more semantic. 
- Cards now display "Premiär" if `new Date(movie.year) > new Date()`.
- Implemented a fallback to `''` if no screening exist or if movies has been released.

Fixes #58 & #57 

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Include details of your testing environment, and the tests you performed.

- [x] I've tried updating the DB for different scenarios and everything seems to be working as intended.

### Checklist:
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation if necessary.
- [x] New and existing tests pass with my changes.

### Screenshots
![image](https://github.com/user-attachments/assets/c58d8812-718b-446d-ad9b-01cbf324a239)

Added Superman as closest screening to show that they will displayed in both rows if it is a new movie and has a screening.

![image](https://github.com/user-attachments/assets/abe8dfc5-b2ae-4ac8-91bf-adebecb5c3bc)


### Additional Notes
We can increase the 5 movies limit if needed.
