### PR TITLE
feat: Create a error message component

### DIFF
--- a/src/components/ErrorMessage.jsx
+++ b/src/components/ErrorMessage.jsx
@@ -1,0 +1,18 @@
+import { Wrench } from "lucide-react";
+
+const ErrorMessage = ({ error }) => {
+    return (
+        <div
+            className="flex flex-col items-center justify-center h-64 my-6 text-center border-4 rounded-md border-red-400 shadow-[inset_0_0_10px_#f87171,0_0_20px_#f87171] px-5 mx-auto max-w-lg"
+        >
+            <Wrench
+                width={100}
+                height={100}
+                className="text-red-400"
+            />
+            <p className="text-red-400 text-xl font-bold">{error}</p>
+        </div>
+    )
+}
+
+export default ErrorMessage;


### PR DESCRIPTION
### Description
I've created a uniformed error message component which takes `{error}` as a prop.

For example on the frontpage of our website we can implement several error states if we want it more versatile. One for live events, one for events, one for upcoming movies and one for currently showing movies. This allows for more specific error messages to be displayed for each section, improving user feedback.

### Example
```
const [currentMoviesError, setCurrentMoviesError] = useState(null);
const [upcomingMoviesError, setupcomingMoviesError] = useState(null);
const [eventsError, setEventsError] = useState(null);
const [liveEventsError, setLiveEventsError] = useState(null);
```

```
{error && (
  <ErrorMessage
      error={currentMoviesError}
   />
)}
```
Or simply just
```
const [error, setError] = useState(null);
```

```
{error && (
  <ErrorMessage
      error={error}
   />
)}
```


Fixes #96 

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Include details of your testing environment, and the tests you performed.

- [x] I've tried it on the frontpage by importing it and inserting it over a map. Then removed one letter from the fetch url for that specific map.

### Checklist:
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my own code.
- [x] I have updated the documentation if necessary.
- [x] New and existing tests pass with my changes.

### Screenshot
![image](https://github.com/user-attachments/assets/e0c9a5fc-6d6f-4bb9-9111-7385bc07b44a)

### Additional Information
I've not implemented this in the code yet. I will do it once Lighthouse analysis issues are merged to avoid conflict.
