### PR TITLE
How Tickets are Sorted

### DIFF
--- a/src/app/membership/page.jsx
+++ b/src/app/membership/page.jsx
@@ -18,7 +18,7 @@ export default function MembershipPage() {
   const menuRef = useRef(null);
   const [expandedTickets, setExpandedTickets] = useState({});
   const [showAllTickets, setShowAllTickets] = useState(false);
-  const sortedBookings = [...booking].sort((a, b) => new Date(a.screeningTime) - new Date(b.screeningTime));
+  const sortedBookings = [...booking].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
 
   const toggleExpand = useCallback((id) => {
     setExpandedTickets((prev) => ({


### PR DESCRIPTION
### Description
Changed how tickets are sorted on /membership so now it is the most recently booked ticket showing up at the top instead of it being sorted by screening date.

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
Visually and by booking random tickets. 

- [ ] Test A
- [ ] Test B

### Checklist:
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation if necessary.
- [ ] New and existing tests pass with my changes.

### Additional Notes
Add any other relevant information here.
