### PR TITLE
cypress test for event page flow

### DIFF
--- a/cypress/e2e/eventPage.cy.js
+++ b/cypress/e2e/eventPage.cy.js
@@ -1,0 +1,31 @@
+describe('User Flow: find the right event navigation', () => {
+	it('Should navigate from homepage to the Swan Lake event in the "live på bio" tab', () => {
+		// 1.visit the homepage
+		cy.visit('/');
+		cy.url().should('eq', `${Cypress.config().baseUrl}/`);
+
+		// 2. Find the heading "Star Wars Maraton"
+		cy.contains('h1', 'Star Wars Maraton').should('be.visible');
+
+		// 3. Click on "Läs mer" related to Star Wars Maraton
+		cy.contains('Star Wars Maraton')
+			.parentsUntil('section') //
+			.find('a')
+			.contains('LÄS MER')
+			.click();
+
+		// 4. Ensure we are on the event page
+		cy.url().should('include', '/events'); //adjust if events?tab=tab2
+
+		// 5. Check that we're on the "Evenemang" tab
+		cy.get('[role="tablist"]').within(() => {
+			cy.contains('Evenemang').should('have.attr', 'aria-selected', 'true');
+		});
+
+		// 6.Click on the "Live på bio" tab
+		cy.contains('[role="tab"]', 'Live på Kino').click();
+
+		// 7.Find the heading "Swan Lake"
+		cy.contains('h2', 'Swan Lake').should('be.visible');
+	});
+});


### PR DESCRIPTION
### Description
Adds an end-to-end Cypress test that validates the user journey from the homepage to locating the "Swan Lake" event under the "Live på Kino" tab, starting by interacting with the "Star Wars Maraton" section.

- Navigating from the homepage to the "Star Wars Maraton" event.

- Clicking the "LÄS MER" link.

- Ensuring the user is routed to the /events page.

- Verifying the correct default tab ("Evenemang") is active.

- Switching to the "Live på Kino" tab.

- Ensuring the "Swan Lake" heading is visible on that tab.

### Test file
- eventPage.cy.js

Fixes # (issue)

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Include details of your testing environment, and the tests you performed.

- [ ] Test A
- [ ] Test B

### Checklist:
- [x] My code follows the project's code style.
- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation if necessary.
- [x] New and existing tests pass with my changes.

### Additional Notes
![image](https://github.com/user-attachments/assets/b1061f24-6766-4fa8-8bd7-578af85ea580)
