### PR TITLE
fix so that singlemovie page works on build

### DIFF
--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -13,15 +13,17 @@ const Movie = async ({ params }: MoviePageProps) => {
 
   // get host from headers to build URL
   const headersList = await headers(); // headers() is synchronous
-  const host = headersList.get('host');
-  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
+  const host = headersList.get('host') || 'localhost:3000';
+  const protocol = headersList.get('x-forwarded-proto') || 'http';
+  // const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https';
   const baseUrl = `${protocol}://${host}`;
 
   try {
     const res = await fetch(`${baseUrl}/api/movies/${id}`, {
       cache: 'no-store',
     });
-    if (!res.ok) throw new Error(`Failed to fetch Movie (status: ${res.status})`);
+    if (!res.ok)
+      throw new Error(`Failed to fetch Movie (status: ${res.status})`);
 
     const movie = await res.json();
     return (


### PR DESCRIPTION
### Description
fixed so that after build we can test the single movie page with npm start with out and issue


Fixes # (issue)

```const host = headersList.get('host') || 'localhost:3000';```

made a change here so it grabs the hostname ( e.g render.com) from the request or localhost:3000

```const protocol = headersList.get('x-forwarded-proto') || 'http';```

fixed my original problem, now it checks for the actual protocol (e.g 'http' or 'https')

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Include details
of your testing environment, and the tests you performed.

- [x] tested by running npm build and then npm start and checking the single movie pages
- [x] tested npm run dev in the same way

### Checklist:

- [ ] My code follows the project's code style.
- [ ] I have performed a self-review of my own code.
- [ ] I have updated the documentation if necessary.
- [ ] New and existing tests pass with my changes.

### Additional Notes

Add any other relevant information here.
